### PR TITLE
Fully isomorphic implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ None.
 ### Dev-Dependencies
 
 * typescript - for compiling the typescript source files to javascript
-* @types/node - typescript definitions for node's API
 
 Optionally:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,19 @@
 {
   "name": "tinywasi",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tinywasi",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^17.0.21",
         "typescript": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=17.4.0"
       }
-    },
-    "node_modules/@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
-      "dev": true
     },
     "node_modules/typescript": {
       "version": "4.6.2",
@@ -34,12 +30,6 @@
     }
   },
   "dependencies": {
-    "@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
-      "dev": true
-    },
     "typescript": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "engines": {
-      "node": "^14.19.0 || >=16.0.0"
+      "node": ">=17.4.0"
   },
   "license": "MIT",
   "author": "QRDate.org + contributors",
@@ -23,7 +23,6 @@
       "url": "https://github.com/qrdate/tinywasi.git"
   },
   "devDependencies": {
-    "@types/node": "^17.0.21",
     "typescript": "^4.6.2"
   },
 	"files": [

--- a/src/TinyWASI.ts
+++ b/src/TinyWASI.ts
@@ -1,5 +1,3 @@
-import * as crypto from 'crypto';
-
 export class TinyWASI {
     private instance?: WebAssembly.Instance = undefined;
 
@@ -210,7 +208,7 @@ export class TinyWASI {
 
         const buffer = new Uint8Array(memory.buffer, pointer, size);
 
-        crypto.randomFillSync(buffer);
+        crypto.getRandomValues(buffer);
 
         return this.WASI_ERRNO_SUCCESS;
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,6 @@
 		"declaration": true,
 		"rootDir": "./src",
 		"outDir": "./dist",
-		"strict": true,
-		"types": [
-			"node"
-		],
+		"strict": true
 	}
 }


### PR DESCRIPTION
By removing the Node crypto import and replacing it with webcrypto [`getRandomValues()`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues) the implementation becomes fully browser compatible. 🎉 

### Detail
- Upgrade engine to v17.4 (released Jan 2022) where webcrypto getRandomValues() was introduced (https://nodejs.org/en/blog/release/v17.4.0)
- Remove redundant node types
- Update readme